### PR TITLE
Connector improvements

### DIFF
--- a/src/elements/connector.rs
+++ b/src/elements/connector.rs
@@ -1,14 +1,17 @@
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
 use super::SvgElement;
 use crate::context::ElementMap;
 use crate::errors::{Result, SvgdxError};
-use crate::geometry::{parse_el_loc, strp_length, Length, LocSpec, ScalarSpec};
+use crate::geometry::{parse_el_loc, strp_length, BoundingBox, Length, LocSpec, ScalarSpec};
 use crate::types::{attr_split, fstr, strp};
 
 pub fn is_connector(el: &SvgElement) -> bool {
     el.has_attr("start") && el.has_attr("end") && (el.name() == "line" || el.name() == "polyline")
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 enum Direction {
     Up,
     Right,
@@ -135,6 +138,31 @@ fn shortest_link(
     Ok((this_min_loc, that_min_loc))
 }
 
+#[derive(PartialEq, Eq)]
+struct HeapData {
+    cost: u32,
+    ind: usize,
+}
+
+impl Ord for HeapData {
+    // from the exaple heap docs
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Notice that we flip the ordering on costs.
+        // In case of a tie we compare positions - this step is necessary
+        // to make implementations of `PartialEq` and `Ord` consistent.
+        other
+            .cost
+            .cmp(&self.cost)
+            .then_with(|| self.ind.cmp(&other.ind))
+    }
+}
+
+impl PartialOrd for HeapData {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 impl Connector {
     fn loc_to_dir(loc: LocSpec) -> Option<Direction> {
         match loc {
@@ -146,18 +174,64 @@ impl Connector {
         }
     }
 
+    fn parse_element<'a>(
+        element: &mut SvgElement,
+        elem_map: &'a impl ElementMap,
+        start: bool,
+    ) -> Result<(
+        Option<&'a SvgElement>,
+        Option<LocSpec>,
+        Option<(f32, f32)>,
+        Option<Direction>,
+    )> {
+        let attrib_name = if start { "start" } else { "end" };
+        let this_ref = element
+            .pop_attr(attrib_name)
+            .ok_or_else(|| SvgdxError::MissingAttribute(attrib_name.to_string()))?;
+
+        let mut t_el: Option<&SvgElement> = None;
+        let mut t_loc: Option<LocSpec> = None;
+        let mut t_point: Option<(f32, f32)> = None;
+        let mut t_dir: Option<Direction> = None;
+
+        // Example: "#thing@tl" => top left coordinate of element id="thing"
+        if let Ok((elref, loc)) = parse_el_loc(&this_ref) {
+            if let Some(loc) = loc {
+                t_dir = Self::loc_to_dir(loc);
+                t_loc = Some(loc);
+            }
+            t_el = elem_map.get_element(&elref);
+        } else {
+            let mut parts = attr_split(&this_ref).map_while(|v| strp(&v).ok());
+            t_point = Some((
+                parts.next().ok_or_else(|| {
+                    SvgdxError::InvalidData(
+                        (attrib_name.to_owned() + "_ref x should be numeric").to_owned(),
+                    )
+                })?,
+                parts.next().ok_or_else(|| {
+                    SvgdxError::InvalidData(
+                        (attrib_name.to_owned() + "_ref y should be numeric").to_owned(),
+                    )
+                })?,
+            ));
+        }
+
+        return Ok((t_el, t_loc, t_point, t_dir));
+    }
+
     pub fn from_element(
         element: &SvgElement,
         elem_map: &impl ElementMap,
         conn_type: ConnectionType,
     ) -> Result<Self> {
         let mut element = element.clone();
-        let start_ref = element
-            .pop_attr("start")
-            .ok_or_else(|| SvgdxError::MissingAttribute("start".to_string()))?;
-        let end_ref = element
-            .pop_attr("end")
-            .ok_or_else(|| SvgdxError::MissingAttribute("end".to_string()))?;
+
+        let (start_el, mut start_loc, start_point, mut start_dir) =
+            Self::parse_element(&mut element, elem_map, true)?;
+        let (end_el, mut end_loc, end_point, mut end_dir) =
+            Self::parse_element(&mut element, elem_map, false)?;
+
         let offset = if let Some(o_inner) = element.pop_attr("corner-offset") {
             Some(
                 strp_length(&o_inner)
@@ -171,50 +245,6 @@ impl Connector {
         // Needs to support explicit coordinate pairs or element references, and
         // for element references support given locations or not (in which case
         // the location is determined automatically to give the shortest distance)
-        let mut start_el: Option<&SvgElement> = None;
-        let mut end_el: Option<&SvgElement> = None;
-        let mut start_loc: Option<LocSpec> = None;
-        let mut end_loc: Option<LocSpec> = None;
-        let mut start_point: Option<(f32, f32)> = None;
-        let mut end_point: Option<(f32, f32)> = None;
-        let mut start_dir: Option<Direction> = None;
-        let mut end_dir: Option<Direction> = None;
-
-        // Example: "#thing@tl" => top left coordinate of element id="thing"
-        if let Ok((elref, loc)) = parse_el_loc(&start_ref) {
-            if let Some(loc) = loc {
-                start_dir = Self::loc_to_dir(loc);
-                start_loc = Some(loc);
-            }
-            start_el = elem_map.get_element(&elref);
-        } else {
-            let mut parts = attr_split(&start_ref).map_while(|v| strp(&v).ok());
-            start_point = Some((
-                parts.next().ok_or_else(|| {
-                    SvgdxError::InvalidData("start_ref x should be numeric".to_owned())
-                })?,
-                parts.next().ok_or_else(|| {
-                    SvgdxError::InvalidData("start_ref y should be numeric".to_owned())
-                })?,
-            ));
-        }
-        if let Ok((elref, loc)) = parse_el_loc(&end_ref) {
-            if let Some(loc) = loc {
-                end_dir = Self::loc_to_dir(loc);
-                end_loc = Some(loc);
-            }
-            end_el = elem_map.get_element(&elref);
-        } else {
-            let mut parts = attr_split(&end_ref).map_while(|v| strp(&v).ok());
-            end_point = Some((
-                parts.next().ok_or_else(|| {
-                    SvgdxError::InvalidData("end_ref x should be numeric".to_owned())
-                })?,
-                parts.next().ok_or_else(|| {
-                    SvgdxError::InvalidData("end_ref y should be numeric".to_owned())
-                })?,
-            ));
-        }
 
         let (start, end) = match (start_point, end_point) {
             (Some(start_point), Some(end_point)) => (
@@ -309,6 +339,310 @@ impl Connector {
         })
     }
 
+    fn aals_blocked_by_bb(bb: BoundingBox, a: f32, b: f32, x_axis: bool, axis_val: f32) -> bool {
+        if x_axis {
+            if axis_val < bb.y1 || axis_val > bb.y2 {
+                return false;
+            }
+            if (a < bb.x1) == (b < bb.x1) && (a > bb.x2) == (b > bb.x2) {
+                return false;
+            }
+        } else {
+            if axis_val < bb.x1 || axis_val > bb.x2 {
+                return false;
+            }
+            if (a < bb.y1) == (b < bb.y1) && (a > bb.y2) == (b > bb.y2) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    fn render_match_conner(
+        &self,
+        ratio_offset: f32,
+        start_abs_offset: f32,
+        end_abs_offset: f32,
+        sel_bb: BoundingBox,
+        eel_bb: BoundingBox,
+        abs_offset_set: bool,
+    ) -> Result<Vec<(f32, f32)>> {
+        let (x1, y1) = self.start.origin;
+        let (x2, y2) = self.end.origin;
+
+        // method generates all points it could possibly want to go through then does dijkstras on it
+
+        let mut points: Vec<(f32, f32)>;
+        if let (Some(start_dir_some), Some(end_dir_some)) = (self.start.dir, self.end.dir) {
+            points = vec![];
+
+            // x_lines have constant x vary over y
+            let mut x_lines = vec![];
+            let mut y_lines = vec![];
+            let mut point_set = vec![];
+            let mut mid_x = std::usize::MAX;
+            let mut mid_y = std::usize::MAX;
+
+            x_lines.push(sel_bb.x1 - start_abs_offset);
+            x_lines.push(sel_bb.x2 + start_abs_offset);
+            x_lines.push(eel_bb.x1 - end_abs_offset);
+            x_lines.push(eel_bb.x2 + end_abs_offset);
+
+            if sel_bb.x1 > eel_bb.x2 {
+                // there is a gap
+                x_lines.push((sel_bb.x1 + eel_bb.x2) * 0.5);
+                mid_x = x_lines.len() - 1;
+            } else if sel_bb.x2 < eel_bb.x1 {
+                // there is a gap
+                x_lines.push((sel_bb.x2 + eel_bb.x1) * 0.5);
+                mid_x = x_lines.len() - 1;
+            }
+
+            y_lines.push(sel_bb.y1 - start_abs_offset);
+            y_lines.push(sel_bb.y2 + start_abs_offset);
+            y_lines.push(eel_bb.y1 - end_abs_offset);
+            y_lines.push(eel_bb.y2 + end_abs_offset);
+
+            if sel_bb.y1 > eel_bb.y2 {
+                // there is a gap
+                y_lines.push(sel_bb.y1 * (1.0 - ratio_offset) + eel_bb.y2 * ratio_offset);
+                mid_y = y_lines.len() - 1;
+            } else if sel_bb.y2 < eel_bb.y1 {
+                // there is a gap
+                y_lines.push(sel_bb.y2 * (1.0 - ratio_offset) + eel_bb.y1 * ratio_offset);
+                mid_y = y_lines.len() - 1;
+            }
+
+            match start_dir_some {
+                Direction::Left | Direction::Right => {
+                    y_lines.push(y1);
+                }
+                Direction::Down | Direction::Up => {
+                    x_lines.push(x1);
+                }
+            }
+
+            match end_dir_some {
+                Direction::Left | Direction::Right => {
+                    y_lines.push(y2);
+                }
+                Direction::Down | Direction::Up => {
+                    x_lines.push(x2);
+                }
+            }
+
+            if abs_offset_set {
+                match start_dir_some {
+                    Direction::Down => mid_y = 1,  // positive x
+                    Direction::Left => mid_x = 0,  // negative y
+                    Direction::Right => mid_x = 1, // positive y
+                    Direction::Up => mid_y = 0,    // positive x
+                }
+            }
+
+            for i in 0..x_lines.len() {
+                for j in 0..y_lines.len() {
+                    point_set.push((x_lines[i], y_lines[j]));
+                }
+            }
+
+            let mut edge_set = vec![vec![]; point_set.len()];
+
+            for i in 0..point_set.len() {
+                for j in 0..point_set.len() {
+                    if i == j {
+                        continue;
+                    }
+                    let mut connected = false;
+
+                    // check if not blocked by a wall
+                    if point_set[i].0 == point_set[j].0 {
+                        if !Self::aals_blocked_by_bb(
+                            sel_bb,
+                            point_set[i].1,
+                            point_set[j].1,
+                            false,
+                            point_set[i].0,
+                        ) && !Self::aals_blocked_by_bb(
+                            eel_bb,
+                            point_set[i].1,
+                            point_set[j].1,
+                            false,
+                            point_set[i].0,
+                        ) {
+                            connected = true;
+                        }
+                    } else if point_set[i].1 == point_set[j].1 {
+                        if !Self::aals_blocked_by_bb(
+                            sel_bb,
+                            point_set[i].0,
+                            point_set[j].0,
+                            true,
+                            point_set[i].1,
+                        ) && !Self::aals_blocked_by_bb(
+                            eel_bb,
+                            point_set[i].0,
+                            point_set[j].0,
+                            true,
+                            point_set[i].1,
+                        ) {
+                            connected = true;
+                        }
+                    }
+                    if connected {
+                        edge_set[i].push(j);
+                        edge_set[j].push(i);
+                    }
+                }
+            }
+
+            // just needs to be bigger than 5* (corner cost  +  total bounding box size)
+            let inf = 1000000;
+
+            point_set.push((x1, y1)); // start
+            point_set.push((x2, y2)); // end
+            edge_set.push(vec![]);
+            edge_set.push(vec![]);
+            let mut queue: BinaryHeap<HeapData> = BinaryHeap::new();
+            let mut dist = vec![inf; point_set.len()];
+
+            let start_ind = edge_set.len() - 2;
+            let end_ind = edge_set.len() - 1;
+            for i in 0..point_set.len() - 2 {
+                if (point_set[i].0 == x1 && point_set[i].1 < y1 && start_dir_some == Direction::Up)
+                    || (point_set[i].0 == x1
+                        && point_set[i].1 > y1
+                        && start_dir_some == Direction::Down)
+                {
+                    if !Self::aals_blocked_by_bb(eel_bb, point_set[i].1, y1, false, x1) {
+                        edge_set[i].push(start_ind);
+                        edge_set[start_ind].push(i);
+                    }
+                }
+                if (point_set[i].1 == y1
+                    && point_set[i].0 > x1
+                    && start_dir_some == Direction::Right)
+                    || (point_set[i].1 == y1
+                        && point_set[i].0 < x1
+                        && start_dir_some == Direction::Left)
+                {
+                    if !Self::aals_blocked_by_bb(eel_bb, point_set[i].0, x1, true, y1) {
+                        edge_set[i].push(start_ind);
+                        edge_set[start_ind].push(i);
+                    }
+                }
+
+                if (point_set[i].0 == x2 && point_set[i].1 < y2 && end_dir_some == Direction::Up)
+                    || (point_set[i].0 == x2
+                        && point_set[i].1 > y2
+                        && end_dir_some == Direction::Down)
+                {
+                    if !Self::aals_blocked_by_bb(sel_bb, point_set[i].1, y2, false, x2) {
+                        edge_set[i].push(end_ind);
+                        edge_set[end_ind].push(i);
+                    }
+                }
+                if (point_set[i].1 == y2 && point_set[i].0 > x2 && end_dir_some == Direction::Right)
+                    || (point_set[i].1 == y2
+                        && point_set[i].0 < x2
+                        && end_dir_some == Direction::Left)
+                {
+                    if !Self::aals_blocked_by_bb(sel_bb, point_set[i].0, x2, true, y2) {
+                        edge_set[i].push(end_ind);
+                        edge_set[end_ind].push(i);
+                    }
+                }
+            }
+
+            // edge cost function
+            let corner_cost = 1000;
+            let mut edge_costs = vec![vec![]; edge_set.len()];
+            for i in 0..edge_set.len() {
+                for j in 0..edge_set[i].len() {
+                    let ind_1 = i;
+                    let ind_2 = edge_set[i][j];
+
+                    let mid_point_mul_x =
+                        if mid_x != std::usize::MAX && point_set[ind_1].0 == x_lines[mid_x] {
+                            0.5
+                        } else {
+                            1.0
+                        };
+                    let mid_point_mul_y =
+                        if mid_y != std::usize::MAX && point_set[ind_1].1 == y_lines[mid_y] {
+                            0.5
+                        } else {
+                            1.0
+                        };
+
+                    edge_costs[i].push(
+                        ((point_set[ind_1].0 - point_set[ind_2].0).abs() * mid_point_mul_y
+                            + (point_set[ind_1].1 - point_set[ind_2].1).abs() * mid_point_mul_x)
+                            as u32
+                            + corner_cost,
+                    ); // round may cause some problems
+                }
+            }
+
+            dist[start_ind] = 0;
+            queue.push(HeapData {
+                cost: 0,
+                ind: start_ind,
+            });
+
+            // cant get stuck in a loop as cost for a distance either decreases or queue shrinks
+            while !queue.is_empty() {
+                let next = queue.pop().expect("would not be in while loop");
+                if next.ind == end_ind {
+                    break;
+                }
+
+                // the node is reached by faster means so already popped
+                if next.cost > dist[next.ind] {
+                    continue;
+                }
+
+                for i in 0..edge_set[next.ind].len() {
+                    let edge_cost = edge_costs[next.ind][i];
+                    if dist[next.ind] + edge_cost < dist[edge_set[next.ind][i]] {
+                        dist[edge_set[next.ind][i]] = dist[next.ind] + edge_cost;
+                        queue.push(HeapData {
+                            cost: dist[edge_set[next.ind][i]],
+                            ind: edge_set[next.ind][i],
+                        });
+                    }
+                }
+            }
+
+            let mut back_points_inds = vec![end_ind];
+            let mut loc = end_ind;
+            while loc != start_ind {
+                // would get stuck in a loop if no valid solution
+                let mut quit = true;
+                for i in 0..edge_set[loc].len() {
+                    if dist[edge_set[loc][i]] + edge_costs[loc][i] == dist[loc] {
+                        loc = edge_set[loc][i];
+                        back_points_inds.push(loc);
+                        quit = false;
+                        break;
+                    }
+                }
+                if quit {
+                    break;
+                }
+            }
+
+            for i in (0..back_points_inds.len()).rev() {
+                points.push(point_set[back_points_inds[i]]);
+            }
+        } else {
+            points = vec![(x1, y1), (x2, y2)];
+        }
+
+        return Ok(points);
+    }
+
     pub fn render(&self, ctx: &impl ElementMap) -> Result<SvgElement> {
         let default_ratio_offset = Length::Ratio(0.5);
         let default_abs_offset = Length::Absolute(3.);
@@ -394,96 +728,42 @@ impl Connector {
             )
             .with_attrs_from(&self.source_element),
             ConnectionType::Corner => {
-                let points;
-                if let (Some(start_dir_some), Some(end_dir_some)) = (self.start.dir, self.end.dir) {
-                    points = match (start_dir_some, end_dir_some) {
-                        // L-shaped connection
-                        (Direction::Up | Direction::Down, Direction::Left | Direction::Right) => {
-                            vec![(x1, y1), (self.start.origin.0, self.end.origin.1), (x2, y2)]
-                        }
-                        (Direction::Left | Direction::Right, Direction::Up | Direction::Down) => {
-                            vec![(x1, y1), (self.end.origin.0, self.start.origin.1), (x2, y2)]
-                        }
-                        // Z-shaped connection
-                        (Direction::Left, Direction::Right)
-                        | (Direction::Right, Direction::Left) => {
-                            let mid_x = self
-                                .offset
-                                .unwrap_or(default_ratio_offset)
-                                .calc_offset(self.start.origin.0, self.end.origin.0);
-                            vec![(x1, y1), (mid_x, y1), (mid_x, y2), (x2, y2)]
-                        }
-                        (Direction::Up, Direction::Down) | (Direction::Down, Direction::Up) => {
-                            let mid_y = self
-                                .offset
-                                .unwrap_or(default_ratio_offset)
-                                .calc_offset(self.start.origin.1, self.end.origin.1);
-                            vec![(x1, y1), (x1, mid_y), (x2, mid_y), (x2, y2)]
-                        }
-                        // U-shaped connection
-                        (Direction::Left, Direction::Left) => {
-                            let min_x = self.start.origin.0.min(self.end.origin.0);
-                            let mid_x = min_x
-                                - self
-                                    .offset
-                                    .unwrap_or(default_abs_offset)
-                                    .absolute()
-                                    .ok_or_else(|| {
-                                        SvgdxError::InvalidData(
-                                            "Corner type requires absolute offset".to_owned(),
-                                        )
-                                    })?;
-                            vec![(x1, y1), (mid_x, y1), (mid_x, y2), (x2, y2)]
-                        }
-                        (Direction::Right, Direction::Right) => {
-                            let max_x = self.start.origin.0.max(self.end.origin.0);
-                            let mid_x = max_x
-                                + self
-                                    .offset
-                                    .unwrap_or(default_abs_offset)
-                                    .absolute()
-                                    .ok_or_else(|| {
-                                        SvgdxError::InvalidData(
-                                            "Corner type requires absolute offset".to_owned(),
-                                        )
-                                    })?;
-
-                            vec![(x1, y1), (mid_x, y1), (mid_x, y2), (x2, y2)]
-                        }
-                        (Direction::Up, Direction::Up) => {
-                            let min_y = self.start.origin.1.min(self.end.origin.1);
-                            let mid_y = min_y
-                                - self
-                                    .offset
-                                    .unwrap_or(default_abs_offset)
-                                    .absolute()
-                                    .ok_or_else(|| {
-                                        SvgdxError::InvalidData(
-                                            "Corner type requires absolute offset".to_owned(),
-                                        )
-                                    })?;
-
-                            vec![(x1, y1), (x1, mid_y), (x2, mid_y), (x2, y2)]
-                        }
-                        (Direction::Down, Direction::Down) => {
-                            let max_y = self.start.origin.1.max(self.end.origin.1);
-                            let mid_y = max_y
-                                + self
-                                    .offset
-                                    .unwrap_or(default_abs_offset)
-                                    .absolute()
-                                    .ok_or_else(|| {
-                                        SvgdxError::InvalidData(
-                                            "Corner type requires absolute offset".to_owned(),
-                                        )
-                                    })?;
-
-                            vec![(x1, y1), (x1, mid_y), (x2, mid_y), (x2, y2)]
-                        }
-                    };
-                } else {
-                    points = vec![(x1, y1), (x2, y2)];
+                let mut abs_offset_set = false;
+                let mut start_abs_offset = default_abs_offset.absolute().ok_or("blarg 13872199")?;
+                let mut end_abs_offset = start_abs_offset;
+                let mut ratio_offset = default_ratio_offset.ratio().ok_or("blarg 13872198")?;
+                if let Some(offset) = &self.offset {
+                    if let Some(o) = offset.absolute() {
+                        start_abs_offset = o;
+                        end_abs_offset = o;
+                        abs_offset_set = true;
+                    }
+                    if let Some(r) = offset.ratio() {
+                        ratio_offset = r;
+                    }
                 }
+
+                let mut sel_bb = BoundingBox::new(x1, y1, x1, y1);
+                let mut eel_bb = BoundingBox::new(x2, y2, x2, y2);
+                if let Some(el) = &self.start_el {
+                    if let Ok(Some(el_bb)) = el.bbox() {
+                        sel_bb = el_bb;
+                    }
+                }
+                if let Some(el) = &self.end_el {
+                    if let Ok(Some(el_bb)) = el.bbox() {
+                        eel_bb = el_bb;
+                    }
+                }
+                let points = self.render_match_conner(
+                    ratio_offset,
+                    start_abs_offset,
+                    end_abs_offset,
+                    sel_bb,
+                    eel_bb,
+                    abs_offset_set,
+                )?;
+
                 // TODO: remove repeated points.
                 if points.len() == 2 {
                     SvgElement::new(

--- a/src/elements/layout.rs
+++ b/src/elements/layout.rs
@@ -866,7 +866,7 @@ fn eval_text_anchor(element: &mut SvgElement, ctx: &impl ContextView) -> Result<
                     LocSpec::BottomEdge(_) => element.set_default_attr("text-loc", "b"),
                     LocSpec::LeftEdge(_) => element.set_default_attr("text-loc", "l"),
                     LocSpec::RightEdge(_) => element.set_default_attr("text-loc", "r"),
-                    LocSpec::PureLength(_) => element.set_default_attr("text-loc", "c"),// not sure
+                    LocSpec::PureLength(_) => element.set_default_attr("text-loc", "c"), // not sure
                 }
             } else {
                 return Err(SvgdxError::InvalidData(format!(

--- a/src/elements/layout.rs
+++ b/src/elements/layout.rs
@@ -866,6 +866,7 @@ fn eval_text_anchor(element: &mut SvgElement, ctx: &impl ContextView) -> Result<
                     LocSpec::BottomEdge(_) => element.set_default_attr("text-loc", "b"),
                     LocSpec::LeftEdge(_) => element.set_default_attr("text-loc", "l"),
                     LocSpec::RightEdge(_) => element.set_default_attr("text-loc", "r"),
+                    LocSpec::PureLength(_) => element.set_default_attr("text-loc", "c"),// not sure
                 }
             } else {
                 return Err(SvgdxError::InvalidData(format!(

--- a/src/geometry/bbox.rs
+++ b/src/geometry/bbox.rs
@@ -65,7 +65,7 @@ impl BoundingBox {
             RightEdge(len) => (self.x2, len.calc_offset(self.y1, self.y2)),
             BottomEdge(len) => (len.calc_offset(self.x1, self.x2), self.y2),
             LeftEdge(len) => (self.x1, len.calc_offset(self.y1, self.y2)),
-            PureLength(len) => panic!(),
+            PureLength(_) => panic!(),
         }
     }
 

--- a/src/geometry/bbox.rs
+++ b/src/geometry/bbox.rs
@@ -65,6 +65,7 @@ impl BoundingBox {
             RightEdge(len) => (self.x2, len.calc_offset(self.y1, self.y2)),
             BottomEdge(len) => (len.calc_offset(self.x1, self.x2), self.y2),
             LeftEdge(len) => (self.x1, len.calc_offset(self.y1, self.y2)),
+            PureLength(len) => panic!(),
         }
     }
 

--- a/src/geometry/types.rs
+++ b/src/geometry/types.rs
@@ -139,6 +139,7 @@ pub enum LocSpec {
     RightEdge(Length),
     BottomEdge(Length),
     LeftEdge(Length),
+    PureLength(Length),
 }
 
 impl LocSpec {
@@ -193,6 +194,7 @@ impl FromStr for LocSpec {
                         "r" => Ok(Self::RightEdge(len)),
                         "b" => Ok(Self::BottomEdge(len)),
                         "l" => Ok(Self::LeftEdge(len)),
+                        "" => Ok(Self::PureLength(len)),
                         _ => Err(SvgdxError::InvalidData(format!(
                             "Invalid LocSpec format {value}"
                         ))),


### PR DESCRIPTION
Various connector improvements, can now do connectors with more than 2 corners, can refer to points on a line like element by using `#id@:40%` and can make connector corners rounded.